### PR TITLE
[codex] Add message widget time templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,55 @@ curl -X PUT http://localhost:8080/api/v1/admin/devices/esp32-001 \
   }'
 ```
 
+### Message Widget Templates
+
+`message` widgets can render server-side placeholders at poll time while still sending a normal `"type": "message"` instruction to devices.
+
+Supported placeholders:
+
+| Placeholder | Default output | Notes |
+|-------------|----------------|-------|
+| `{{date}}` | `Mon Jan 2` | Accepts a Go `time.Format` layout after `:` and optional timezone after `|` |
+| `{{time}}` | `3:04 PM` | Accepts a Go `time.Format` layout after `:` and optional timezone after `|` |
+| `{{datetime}}` | `Mon Jan 2 3:04 PM` | Accepts a Go `time.Format` layout after `:` and optional timezone after `|` |
+| `{{now}}` | RFC3339 timestamp | Accepts a Go `time.Format` layout after `:` and optional timezone after `|` |
+| `{{redis}}` | Redis key value | Uses the message widget's `redis_key` |
+
+Timezone handling:
+
+- No timezone suffix uses the server's local timezone.
+- `|UTC` renders in UTC.
+- `|America/Chicago` and other IANA timezone names are supported.
+- Invalid timezone names are left unrendered so configuration mistakes are visible.
+
+Examples:
+
+```json
+{
+  "type": "message",
+  "text": "Today is {{date:Mon Jan 2}}",
+  "scroll_speed_ms": 50,
+  "repeats": 2
+}
+```
+
+```json
+{
+  "type": "message",
+  "text": "Temp {{redis}} as of {{time:15:04}}",
+  "redis_key": "kurokku:temperature"
+}
+```
+
+```json
+{
+  "type": "message",
+  "text": "UTC {{time:15:04|UTC}}  Chicago {{time:3:04 PM|America/Chicago}}"
+}
+```
+
+If `redis_key` is set and the message text contains no placeholders, the existing behavior is preserved: the Redis value replaces the entire message text.
+
 ## Alert Integration
 
 Alerts are stored as individual Redis keys at `kurokku:alert:<id>`, each containing a JSON object:

--- a/internal/playlist/resolver.go
+++ b/internal/playlist/resolver.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -13,6 +15,8 @@ import (
 	"github.com/swilcox/kurokku-esp-server/internal/model"
 	"github.com/swilcox/kurokku-esp-server/internal/solar"
 )
+
+var messageTemplatePattern = regexp.MustCompile(`\{\{\s*([a-zA-Z_]+)(?::([^}]*))?\s*\}\}`)
 
 // Resolver determines what a device should display based on its
 // playlist and ephemeral Redis state.
@@ -46,7 +50,6 @@ func NewResolver(rdb *redis.Client, logger *slog.Logger, opts Options) *Resolver
 func stateKey(deviceID string) string {
 	return fmt.Sprintf("device:%s:playlist_state", deviceID)
 }
-
 
 // Resolve returns the instruction (if any) for a device poll.
 // Returns nil instruction if the current widget's duration hasn't elapsed.
@@ -235,17 +238,127 @@ func (r *Resolver) buildInstruction(ctx context.Context, device *model.Device, e
 func (r *Resolver) buildMessageInstruction(ctx context.Context, entry *model.PlaylistEntry) (*model.Instruction, error) {
 	inst := widgetToInstruction(&entry.Widget, entry.DurationSec)
 
+	var redisValue string
 	if entry.Widget.RedisKey != "" {
 		val, err := r.rdb.Get(ctx, entry.Widget.RedisKey).Result()
 		if err != nil && err != redis.Nil {
 			return nil, fmt.Errorf("reading message key %s from redis: %w", entry.Widget.RedisKey, err)
 		}
 		if err == nil && val != "" {
-			inst.Text = val
+			redisValue = val
 		}
 	}
 
+	if rendered, ok := renderMessageTemplate(inst.Text, redisValue, time.Now()); ok {
+		inst.Text = rendered
+	} else if redisValue != "" {
+		// Preserve the historical behavior when no inline placeholders are used.
+		inst.Text = redisValue
+	}
+
 	return inst, nil
+}
+
+func renderMessageTemplate(text, redisValue string, now time.Time) (string, bool) {
+	matches := messageTemplatePattern.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		return text, false
+	}
+
+	var b strings.Builder
+	last := 0
+	for _, m := range matches {
+		b.WriteString(text[last:m[0]])
+
+		token := strings.ToLower(text[m[2]:m[3]])
+		spec := ""
+		if len(m) >= 6 && m[4] >= 0 && m[5] >= 0 {
+			spec = strings.TrimSpace(text[m[4]:m[5]])
+		}
+		b.WriteString(resolveMessageToken(token, spec, redisValue, now))
+		last = m[1]
+	}
+	b.WriteString(text[last:])
+	return b.String(), true
+}
+
+func resolveMessageToken(token, spec, redisValue string, now time.Time) string {
+	layout, timezone, hasTimezone := parseMessageTokenSpec(spec)
+
+	switch token {
+	case "redis":
+		return redisValue
+	case "date":
+		return formatMessageTimeToken(token, layout, timezone, hasTimezone, "Mon Jan 2", now)
+	case "time":
+		return formatMessageTimeToken(token, layout, timezone, hasTimezone, "3:04 PM", now)
+	case "datetime":
+		return formatMessageTimeToken(token, layout, timezone, hasTimezone, "Mon Jan 2 3:04 PM", now)
+	case "now":
+		return formatMessageTimeToken(token, layout, timezone, hasTimezone, time.RFC3339, now)
+	default:
+		return "{{" + tokenWithSpec(token, spec) + "}}"
+	}
+}
+
+func formatMessageTimeToken(token, layout, timezone string, hasTimezone bool, fallback string, now time.Time) string {
+	t := now
+	if hasTimezone {
+		loc, ok := resolveMessageTimezone(timezone)
+		if !ok {
+			return "{{" + tokenWithSpec(token, buildMessageTokenSpec(layout, timezone, hasTimezone)) + "}}"
+		}
+		t = now.In(loc)
+	}
+	return t.Format(withDefaultLayout(layout, fallback))
+}
+
+func parseMessageTokenSpec(spec string) (layout, timezone string, hasTimezone bool) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return "", "", false
+	}
+
+	parts := strings.SplitN(spec, "|", 2)
+	layout = strings.TrimSpace(parts[0])
+	if len(parts) == 1 {
+		return layout, "", false
+	}
+
+	timezone = strings.TrimSpace(parts[1])
+	return layout, timezone, timezone != ""
+}
+
+func resolveMessageTimezone(name string) (*time.Location, bool) {
+	if strings.EqualFold(name, "UTC") {
+		return time.UTC, true
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return nil, false
+	}
+	return loc, true
+}
+
+func withDefaultLayout(layout, fallback string) string {
+	if strings.TrimSpace(layout) == "" {
+		return fallback
+	}
+	return layout
+}
+
+func tokenWithSpec(token, spec string) string {
+	if spec == "" {
+		return token
+	}
+	return token + ":" + spec
+}
+
+func buildMessageTokenSpec(layout, timezone string, hasTimezone bool) string {
+	if !hasTimezone {
+		return layout
+	}
+	return layout + "|" + timezone
 }
 
 func (r *Resolver) buildAlertInstruction(ctx context.Context, device *model.Device, entry *model.PlaylistEntry) (*model.Instruction, error) {

--- a/internal/playlist/resolver_test.go
+++ b/internal/playlist/resolver_test.go
@@ -175,6 +175,62 @@ func TestResolve_MultiEntry_Advancement(t *testing.T) {
 	}
 }
 
+func TestResolve_MessageRedisKeyStillOverridesPlainText(t *testing.T) {
+	r, mr := setupResolver(t)
+	ctx := context.Background()
+	device := makeDevice("dev-1")
+	mr.Set("kurokku:test:message", "from redis")
+
+	pl := makePlaylist(model.PlaylistEntry{
+		ID:          "e-msg",
+		DurationSec: 10,
+		Widget: model.Widget{
+			Type:     "message",
+			Text:     "static",
+			RedisKey: "kurokku:test:message",
+		},
+	})
+
+	resp, err := r.Resolve(ctx, device, pl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Instruction == nil {
+		t.Fatal("expected instruction")
+	}
+	if resp.Instruction.Text != "from redis" {
+		t.Fatalf("text = %q, want %q", resp.Instruction.Text, "from redis")
+	}
+}
+
+func TestResolve_MessageTemplateCanInsertRedisValue(t *testing.T) {
+	r, mr := setupResolver(t)
+	ctx := context.Background()
+	device := makeDevice("dev-1")
+	mr.Set("kurokku:test:temp", "72F")
+
+	pl := makePlaylist(model.PlaylistEntry{
+		ID:          "e-msg",
+		DurationSec: 10,
+		Widget: model.Widget{
+			Type:     "message",
+			Text:     "Temp {{redis}}",
+			RedisKey: "kurokku:test:temp",
+		},
+	})
+
+	resp, err := r.Resolve(ctx, device, pl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Instruction == nil {
+		t.Fatal("expected instruction")
+	}
+	if resp.Instruction.Text != "Temp 72F" {
+		t.Fatalf("text = %q, want %q", resp.Instruction.Text, "Temp 72F")
+	}
+}
+
 func TestResolve_VersionChange_ResetsToZero(t *testing.T) {
 	r, _ := setupResolver(t)
 	ctx := context.Background()
@@ -195,6 +251,66 @@ func TestResolve_VersionChange_ResetsToZero(t *testing.T) {
 	}
 	if resp.Instruction.Type != "clock" {
 		t.Errorf("version change should reset to index 0 (clock), got %s", resp.Instruction.Type)
+	}
+}
+
+func TestRenderMessageTemplate_TimeTokens(t *testing.T) {
+	now := time.Date(2026, 4, 21, 13, 5, 0, 0, time.UTC)
+
+	got, ok := renderMessageTemplate(
+		"Today {{date:Mon 1/2}} at {{time:15:04}}; full {{datetime:2006-01-02 15:04}}; raw {{now:2006}}",
+		"",
+		now,
+	)
+	if !ok {
+		t.Fatal("expected template render to report placeholders")
+	}
+
+	want := "Today Tue 4/21 at 13:05; full 2026-04-21 13:05; raw 2026"
+	if got != want {
+		t.Fatalf("rendered = %q, want %q", got, want)
+	}
+}
+
+func TestRenderMessageTemplate_TimeTokensWithTimezone(t *testing.T) {
+	now := time.Date(2026, 4, 21, 13, 5, 0, 0, time.UTC)
+
+	got, ok := renderMessageTemplate(
+		"UTC {{time:15:04|UTC}} Central {{time:15:04|America/Chicago}} Date {{date:2006-01-02|America/Chicago}}",
+		"",
+		now,
+	)
+	if !ok {
+		t.Fatal("expected template render to report placeholders")
+	}
+
+	want := "UTC 13:05 Central 08:05 Date 2026-04-21"
+	if got != want {
+		t.Fatalf("rendered = %q, want %q", got, want)
+	}
+}
+
+func TestRenderMessageTemplate_InvalidTimezonePreserved(t *testing.T) {
+	now := time.Date(2026, 4, 21, 13, 5, 0, 0, time.UTC)
+
+	got, ok := renderMessageTemplate("Bad {{time:15:04|Mars/Olympus}}", "", now)
+	if !ok {
+		t.Fatal("expected template render to report placeholders")
+	}
+	if got != "Bad {{time:15:04|Mars/Olympus}}" {
+		t.Fatalf("rendered = %q, want invalid timezone placeholder to remain intact", got)
+	}
+}
+
+func TestRenderMessageTemplate_UnknownTokensPreserved(t *testing.T) {
+	now := time.Date(2026, 4, 21, 13, 5, 0, 0, time.UTC)
+
+	got, ok := renderMessageTemplate("Value {{unknown:test}}", "", now)
+	if !ok {
+		t.Fatal("expected template render to report placeholders")
+	}
+	if got != "Value {{unknown:test}}" {
+		t.Fatalf("rendered = %q, want unknown token to remain intact", got)
 	}
 }
 

--- a/web/templates/playlist_form.html
+++ b/web/templates/playlist_form.html
@@ -74,8 +74,8 @@
 
                             <div class="entry-panel panel-message" {{if ne $e.Widget.Type "message"}}hidden{{end}}>
                                 <div class="entry-field entry-field-wide">
-                                    <label title="Scrolled across the display. Overridden by Redis key value if set and present.">Message text</label>
-                                    <input type="text" name="entry_msg_text_{{$i}}" value="{{$e.Widget.Text}}" placeholder="Hello!">
+                                    <label title="Scrolled across the display. Supports server-rendered placeholders like &#123;&#123;date:Mon Jan 2&#125;&#125;, &#123;&#123;time:3:04 PM&#125;&#125;, &#123;&#123;time:15:04|UTC&#125;&#125;, &#123;&#123;datetime:2006-01-02 15:04|America/Chicago&#125;&#125;, &#123;&#123;now:Mon Jan 2 3:04 PM&#125;&#125;, and &#123;&#123;redis&#125;&#125;. If a Redis key is set and no placeholders are used, its value still replaces the whole message.">Message text</label>
+                                    <input type="text" name="entry_msg_text_{{$i}}" value="{{$e.Widget.Text}}" placeholder="Now &#123;&#123;time:15:04|UTC&#125;&#125;">
                                 </div>
                                 <div class="entry-field">
                                     <label title="Milliseconds per column of scroll. Lower = faster.">Scroll speed (ms/col)</label>
@@ -86,7 +86,7 @@
                                     <input type="number" name="entry_msg_repeats_{{$i}}" value="{{if gt $e.Widget.Repeats 0}}{{$e.Widget.Repeats}}{{else}}0{{end}}" min="0" placeholder="0">
                                 </div>
                                 <div class="entry-field entry-field-wide">
-                                    <label title="If set and key has a value, replaces the message text at display time.">Redis key (optional)</label>
+                                    <label title="Optional Redis value used by &#123;&#123;redis&#125;&#125; or, if no placeholders are present, as the full message override.">Redis key (optional)</label>
                                     <input type="text" name="entry_redis_key_{{$i}}" value="{{entryRedisKey $e}}" placeholder="kurokku:temperature">
                                 </div>
                             </div>


### PR DESCRIPTION
## What changed
- add server-side placeholder rendering for `message` widgets so dates, times, and Redis-backed values can be injected without changing the device contract
- support Go-style time layouts plus optional timezone suffixes such as `|UTC` and `|America/Chicago`
- preserve existing `redis_key` whole-message override behavior when no placeholders are present
- document the new syntax in the admin UI and README
- add resolver tests covering time rendering, timezone handling, Redis insertion, and compatibility behavior

## Why
The server already owns message resolution, so this is the cleanest place to add formatted date/time output without introducing a new widget type across clients. Explicit timezone support also avoids incorrect rendering when a single server needs to show UTC or multiple regional times.

## Impact
Playlists can now use message text like `{{date:Mon Jan 2}}`, `{{time:15:04|UTC}}`, or `Temp {{redis}} as of {{time:15:04}}`.

## Validation
- `go test ./...`
