### PR TITLE
Emit config block in device poll response

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,31 @@ curl -X PUT http://localhost:8080/api/v1/admin/devices/esp32-001 \
   }'
 ```
 
+### Remote Device Config
+
+`syslog_host` and `tz` on a device are pushed to the firmware in the poll
+response's `config` block, letting you change a deployed device's logging target
+or timezone without re-flashing or serial re-provisioning (OTA replaces only the
+firmware image and preserves NVS). The firmware persists them to NVS and applies
+them live — no reboot. It also deduplicates, so the server returns the same
+`config` on every poll without churning the device's flash.
+
+```bash
+curl -X PUT http://localhost:8080/api/v1/admin/devices/esp32-001 \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "display_type": "max7219",
+    "poll_ms": 5000,
+    "syslog_host": "192.168.1.50:5514",
+    "tz": "CST6CDT,M3.2.0,M11.1.0"
+  }'
+```
+
+Both fields are also editable from the device form in the admin UI. Omitting a
+field (or leaving it blank in the form) leaves the device's current value
+untouched. Sending `"syslog_host": ""` via the API explicitly disables syslog on
+the device.
+
 ### Message Widget Templates
 
 `message` widgets can render server-side placeholders at poll time while still sending a normal `"type": "message"` instruction to devices.

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -97,6 +97,7 @@ func (h *Handler) handleDeviceInstruction(w http.ResponseWriter, r *http.Request
 		resp := &model.ServerResponse{
 			Instruction: &model.Instruction{Type: "ota", URL: pending.URL},
 			PollMs:      &pollMs,
+			Config:      deviceConfig(device),
 		}
 		h.recordDeviceStatusWithOTA(ctx, deviceID, r.RemoteAddr, firmwareVersion, resp.Instruction, pending)
 		h.jsonResponse(w, http.StatusOK, resp)
@@ -122,6 +123,7 @@ func (h *Handler) handleDeviceInstruction(w http.ResponseWriter, r *http.Request
 		h.serverError(w, "resolving playlist", err)
 		return
 	}
+	resp.Config = deviceConfig(device)
 
 	hasInstruction := resp.Instruction != nil
 	h.logger.Debug("device instruction response",
@@ -132,6 +134,16 @@ func (h *Handler) handleDeviceInstruction(w http.ResponseWriter, r *http.Request
 	h.recordDeviceStatusWithOTA(ctx, deviceID, r.RemoteAddr, firmwareVersion, resp.Instruction, nil)
 
 	h.jsonResponse(w, http.StatusOK, resp)
+}
+
+// deviceConfig builds the `config` block for a poll response from the device's
+// persisted settings, or nil when the device has nothing to assert. The
+// firmware deduplicates, so returning the same block on every poll is cheap.
+func deviceConfig(d *model.Device) *model.DeviceConfig {
+	if d.SyslogHost == nil && d.Tz == nil {
+		return nil
+	}
+	return &model.DeviceConfig{SyslogHost: d.SyslogHost, Tz: d.Tz}
 }
 
 // recordDeviceStatusWithOTA updates the device's LastSeen/LastInstruction,

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -364,3 +364,49 @@ func TestHandleDeletePlaylist(t *testing.T) {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusNoContent)
 	}
 }
+
+func TestHandleDeviceInstruction_ConfigEmitted(t *testing.T) {
+	h, s := setupHandler(t)
+	ctx := httptest.NewRequest("GET", "/", nil).Context()
+
+	syslog := "192.168.1.50:5514"
+	tz := "CST6CDT,M3.2.0,M11.1.0"
+	s.UpsertDevice(ctx, &model.Device{
+		ID:         "dev-1",
+		PollMs:     5000,
+		SyslogHost: &syslog,
+		Tz:         &tz,
+	})
+
+	req := httptest.NewRequest("GET", "/api/v1/devices/dev-1/instruction", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	var resp model.ServerResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Config == nil {
+		t.Fatal("expected config block, got nil")
+	}
+	if resp.Config.SyslogHost == nil || *resp.Config.SyslogHost != syslog {
+		t.Errorf("syslog_host = %v, want %q", resp.Config.SyslogHost, syslog)
+	}
+	if resp.Config.Tz == nil || *resp.Config.Tz != tz {
+		t.Errorf("tz = %v, want %q", resp.Config.Tz, tz)
+	}
+}
+
+func TestHandleDeviceInstruction_ConfigOmittedWhenUnset(t *testing.T) {
+	h, s := setupHandler(t)
+	ctx := httptest.NewRequest("GET", "/", nil).Context()
+	s.UpsertDevice(ctx, &model.Device{ID: "dev-1", PollMs: 5000})
+
+	req := httptest.NewRequest("GET", "/api/v1/devices/dev-1/instruction", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	// A device with no syslog/tz must not carry a config block at all, so the
+	// firmware isn't asked to reconcile anything every poll.
+	if strings.Contains(w.Body.String(), "\"config\"") {
+		t.Errorf("expected no config key in response, got %s", w.Body.String())
+	}
+}

--- a/internal/api/web.go
+++ b/internal/api/web.go
@@ -507,6 +507,13 @@ func (w *WebHandler) deviceFromForm(r *http.Request) *model.Device {
 		}
 	}
 
+	if sys := strings.TrimSpace(r.FormValue("syslog_host")); sys != "" {
+		d.SyslogHost = &sys
+	}
+	if tz := strings.TrimSpace(r.FormValue("tz")); tz != "" {
+		d.Tz = &tz
+	}
+
 	return d
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -12,23 +12,29 @@ const (
 
 // Device represents a registered ESP32 display device.
 type Device struct {
-	ID          string      `json:"id" db:"id"`
-	Name        string      `json:"name" db:"name"`
-	DisplayType DisplayType `json:"display_type" db:"display_type"`
-	Location    string      `json:"location" db:"location"`
+	ID              string      `json:"id" db:"id"`
+	Name            string      `json:"name" db:"name"`
+	DisplayType     DisplayType `json:"display_type" db:"display_type"`
+	Location        string      `json:"location" db:"location"`
 	Brightness      int         `json:"brightness" db:"brightness"`
 	Latitude        *float64    `json:"latitude,omitempty" db:"latitude"`
 	Longitude       *float64    `json:"longitude,omitempty" db:"longitude"`
 	BrightnessDay   int         `json:"brightness_day" db:"brightness_day"`
 	BrightnessNight int         `json:"brightness_night" db:"brightness_night"`
 	PollMs          int         `json:"poll_ms" db:"poll_ms"`
-	PlaylistID  string      `json:"playlist_id" db:"playlist_id"`
+	PlaylistID      string      `json:"playlist_id" db:"playlist_id"`
 	// LowPriorityAlertCron / LowPriorityThreshold override the server-wide
 	// low-priority alert gating when set. Nil falls back to the Resolver default.
-	LowPriorityAlertCron *string   `json:"low_priority_alert_cron,omitempty" db:"low_priority_alert_cron"`
-	LowPriorityThreshold *int      `json:"low_priority_threshold,omitempty" db:"low_priority_threshold"`
-	CreatedAt            time.Time `json:"created_at" db:"created_at"`
-	UpdatedAt            time.Time `json:"updated_at" db:"updated_at"`
+	LowPriorityAlertCron *string `json:"low_priority_alert_cron,omitempty" db:"low_priority_alert_cron"`
+	LowPriorityThreshold *int    `json:"low_priority_threshold,omitempty" db:"low_priority_threshold"`
+	// SyslogHost / Tz are pushed to the device as a remote `config` update in
+	// the poll response, so the firmware can persist them to NVS without serial
+	// re-provisioning. Nil = not managed (the firmware keeps its current value).
+	// SyslogHost is "host:port" for UDP syslog; Tz is a POSIX TZ string.
+	SyslogHost *string   `json:"syslog_host,omitempty" db:"syslog_host"`
+	Tz         *string   `json:"tz,omitempty" db:"tz"`
+	CreatedAt  time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at" db:"updated_at"`
 }
 
 // Playlist is an ordered list of widget entries that cycle on a device.
@@ -82,9 +88,21 @@ type Widget struct {
 // ServerResponse is the envelope returned to polling devices.
 // Matches the contract in the ESP firmware's CLAUDE.md.
 type ServerResponse struct {
-	Instruction *Instruction `json:"instruction,omitempty"`
-	Brightness  *int         `json:"brightness,omitempty"`
-	PollMs      *int         `json:"poll_interval_ms,omitempty"`
+	Instruction *Instruction  `json:"instruction,omitempty"`
+	Brightness  *int          `json:"brightness,omitempty"`
+	PollMs      *int          `json:"poll_interval_ms,omitempty"`
+	Config      *DeviceConfig `json:"config,omitempty"`
+}
+
+// DeviceConfig is the `config` block in a poll response. It carries persisted
+// device settings the firmware applies live and stores in NVS (syslog target,
+// timezone), so they can change without re-provisioning over serial. The
+// firmware deduplicates, so it's safe to send on every poll. A nil field is
+// omitted from the JSON (the firmware leaves it unchanged); an explicit empty
+// SyslogHost ("") tells the firmware to disable syslog.
+type DeviceConfig struct {
+	SyslogHost *string `json:"syslog_host,omitempty"`
+	Tz         *string `json:"tz,omitempty"`
 }
 
 // Instruction is the wire format for a widget instruction sent to devices.
@@ -133,9 +151,9 @@ type PendingOTA struct {
 // AlertConfig matches the alert structure in led-kurokku-go.
 // Stored in Redis as kurokku:alert:<id>.
 type AlertConfig struct {
-	ID                 string  `json:"id"`
-	Message            string  `json:"message"`
-	Priority           int     `json:"priority"`
-	DisplayDurationStr string  `json:"display_duration"`
-	DeleteAfterDisplay bool    `json:"delete_after_display"`
+	ID                 string `json:"id"`
+	Message            string `json:"message"`
+	Priority           int    `json:"priority"`
+	DisplayDurationStr string `json:"display_duration"`
+	DeleteAfterDisplay bool   `json:"delete_after_display"`
 }

--- a/web/templates/device_form.html
+++ b/web/templates/device_form.html
@@ -119,6 +119,21 @@
             </div>
         </div>
 
+        <div class="form-row">
+            <div class="form-group">
+                <label for="syslog_host">Syslog Host (optional)</label>
+                <input type="text" id="syslog_host" name="syslog_host"
+                       value="{{if .Device.SyslogHost}}{{.Device.SyslogHost}}{{end}}"
+                       placeholder="host:port — e.g. 192.168.1.50:5514">
+            </div>
+            <div class="form-group">
+                <label for="tz">Timezone (optional)</label>
+                <input type="text" id="tz" name="tz"
+                       value="{{if .Device.Tz}}{{.Device.Tz}}{{end}}"
+                       placeholder="POSIX TZ — e.g. CST6CDT,M3.2.0,M11.1.0">
+            </div>
+        </div>
+
         <div class="actions">
             <button type="submit" class="btn btn-primary">{{if .IsNew}}Create Device{{else}}Save Changes{{end}}</button>
             <a href="/admin/devices" class="btn">Cancel</a>


### PR DESCRIPTION
## What

Adds per-device `syslog_host` and `tz` settings that are pushed to the firmware in the poll response's new `config` block, so a deployed device's logging target and timezone can change **without re-flashing or serial re-provisioning**. Companion to the firmware change (swilcox/led-kurokku-esp#remote-config-updates).

## How

- `model.go` — `Device` gains optional `SyslogHost`/`Tz` (`*string`, same idiom as `LowPriorityAlertCron`); new `DeviceConfig`; `ServerResponse.Config`.
- `handler.go` — `deviceConfig()` attaches the block to every device poll response (normal + OTA paths), omitted entirely when the device has neither set so unmanaged devices get no config noise. The firmware deduplicates, so returning the same block every poll is cheap.
- `web.go` + `device_form.html` — Syslog Host and Timezone fields in the admin device form.
- README documents the feature and the API.

## Contract

Omitting a field (or leaving the form blank) leaves the device's current value untouched. Sending `"syslog_host": ""` via the API explicitly disables syslog on the device.

## Testing

- New tests: `TestHandleDeviceInstruction_ConfigEmitted` (set → present & correct) and `TestHandleDeviceInstruction_ConfigOmittedWhenUnset` (absent → no `config` key).
- Full suite green; `go vet` and `gofmt` clean.